### PR TITLE
inject mutex in LogEvent

### DIFF
--- a/src/Console/Scheduling/LogEvent.php
+++ b/src/Console/Scheduling/LogEvent.php
@@ -3,6 +3,7 @@
 namespace PendoNL\LaravelScheduleLogger\Console\Scheduling;
 
 use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Mutex;
 
 class LogEvent extends Event
 {
@@ -12,8 +13,11 @@ class LogEvent extends Event
      * @param string $command
      * @param string $rawCommand
      */
-    public function __construct($command, $rawCommand)
+    public function __construct(Mutex $mutex, $command, $rawCommand)
     {
+        parent::__construct($mutex, $command);
+
+        $this->mutex = $mutex;
         $this->command = $command;
         $this->output = $this->getDefaultOutput();
 

--- a/src/Console/Scheduling/LogSchedule.php
+++ b/src/Console/Scheduling/LogSchedule.php
@@ -48,7 +48,7 @@ class LogSchedule extends Schedule
             $command .= ' '.$this->compileParameters($parameters);
         }
 
-        $this->events[] = $event = new LogEvent($command, $this->rawCommand);
+        $this->events[] = $event = new LogEvent($this->mutex, $command, $this->rawCommand);
 
         return $event;
     }


### PR DESCRIPTION
Fixes lock bug, when calling withoutOverlapping function